### PR TITLE
Create Thread API route

### DIFF
--- a/server/messengerservice/src/main/scala/com/letstalk/JsonSupport.scala
+++ b/server/messengerservice/src/main/scala/com/letstalk/JsonSupport.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import com.letstalk.UserRegistryActor.ActionPerformed
 import com.letstalk.data_models._
-import com.letstalk.routes.{ MessageData, SendMessageResponse }
+import com.letstalk.routes.{ MessageData, SendMessageResponse, CreateThread }
 import spray.json._
 
 import scala.collection.immutable
@@ -59,5 +59,5 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val messageJsonFormat: RootJsonFormat[Message] = jsonFormat4(Message)
   implicit val threadJsonFormat: RootJsonFormat[Thread] = jsonFormat2(Thread)
-  implicit  val createThreadJsonFormmat: RootJsonFormat[CreateThread] = jsonFormat1(CreateThread)
+  implicit val createThreadJsonFormat: RootJsonFormat[CreateThread] = jsonFormat1(CreateThread)
 }

--- a/server/messengerservice/src/main/scala/com/letstalk/data_models/Thread.scala
+++ b/server/messengerservice/src/main/scala/com/letstalk/data_models/Thread.scala
@@ -11,8 +11,6 @@ import com.letstalk.data_layer.MessageEvent
  */
 final case class Thread(id: UUID, userIds: List[UUID]) extends MessageEvent
 
-final case class CreateThread(userIds: List[UUID]) extends MessageEvent
-
 /**
  * The table schema definition for the thread table
  * @param tag

--- a/server/messengerservice/src/main/scala/com/letstalk/routes/MessageRoutes.scala
+++ b/server/messengerservice/src/main/scala/com/letstalk/routes/MessageRoutes.scala
@@ -2,19 +2,21 @@ package com.letstalk.routes
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ ActorRef, ActorSystem }
 import akka.event.Logging
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.pattern.ask
 import akka.util.Timeout
 import com.letstalk.data_layer._
-import com.letstalk.data_models.{CreateThread, IncomingMessagePayload, Message, Thread}
-import com.letstalk.{ChatService, JsonSupport, WithAuth}
+import com.letstalk.data_models.{ IncomingMessagePayload, Message, Thread }
+import com.letstalk.{ ChatService, JsonSupport, WithAuth }
 
 import scala.concurrent.duration._
 
 case class MessageData(sender: UUID, thread: UUID, payload: String)
+
+final case class CreateThread(userIds: List[UUID])
 
 case class SendMessageResponse(messageId: UUID)
 


### PR DESCRIPTION
Implemented api route to use the thread storage logic.

Created a new case class for threads so that we can easily unmarshall data without providing a fake threadID.

Also added some documentation for api routes. I think we should be documenting routes as we go to better help collaboration and communication.

Can test using:

`curl -X POST -H "Content-Type: application/json" --cookie "sid=123e4567-e89b-12d3-a456-426655440000" http://localhost:8080/threads/create -d"{\"userIds\":[\"123e4567-e89b-12d3-a456-426655440000\"]}"`