### PR TITLE
server: return error instead of adding to context

### DIFF
--- a/server/core/ctx/context.go
+++ b/server/core/ctx/context.go
@@ -1,10 +1,6 @@
 package ctx
 
 import (
-	"letstalk/server/core/errs"
-
-	"log"
-
 	"github.com/gin-gonic/gin"
 	"github.com/mijia/modelq/gmq"
 )
@@ -13,22 +9,11 @@ type Context struct {
 	GinContext *gin.Context
 	Db         *gmq.Db
 	Result     interface{}
-	Errors     []errs.Error
 }
 
 func NewContext(g *gin.Context, db *gmq.Db) *Context {
 	return &Context{
 		GinContext: g,
 		Db:         db,
-		Errors:     make([]errs.Error, 0),
 	}
-}
-
-func (c *Context) AddError(e errs.Error) {
-	log.Println("Added error: ", e.Error())
-	c.Errors = append(c.Errors, e)
-}
-
-func (c *Context) HasErrors() bool {
-	return len(c.Errors) > 0
 }

--- a/server/core/ctx/context_test.go
+++ b/server/core/ctx/context_test.go
@@ -1,9 +1,7 @@
 package ctx_test
 
 import (
-	"errors"
 	"letstalk/server/core/ctx"
-	"letstalk/server/core/errs"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -11,13 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/http"
 )
-
-func createTestContext() *ctx.Context {
-	writer := http.TestResponseWriter{}
-	g, _ := gin.CreateTestContext(&writer)
-	db := gmq.Db{}
-	return ctx.NewContext(g, &db)
-}
 
 func TestNewContext(t *testing.T) {
 	writer := http.TestResponseWriter{}
@@ -27,38 +18,4 @@ func TestNewContext(t *testing.T) {
 	assert.Equal(t, db, c.Db)
 	assert.Equal(t, g, c.GinContext)
 	assert.Nil(t, c.Result)
-	assert.Empty(t, c.Errors)
-	assert.False(t, c.HasErrors())
-}
-
-func TestAddError(t *testing.T) {
-	c := createTestContext()
-	assert.False(t, c.HasErrors())
-	const msg = "test message"
-	err := errs.NewClientError(msg)
-	c.AddError(err)
-	assert.True(t, c.HasErrors())
-	assert.Len(t, c.Errors, 1)
-	assert.Equal(t, err.GetHTTPCode(), c.Errors[0].GetHTTPCode())
-	assert.Equal(t, msg, c.Errors[0].Error())
-}
-
-func TestAddErrorMultiple(t *testing.T) {
-	c := createTestContext()
-	assert.False(t, c.HasErrors())
-	messages := []string{"test message 1", "test message 2", "test message 3"}
-	addErrs := []errs.Error{
-		errs.NewClientError(messages[0]),
-		errs.NewInternalError(messages[1]),
-		errs.NewDbError(errors.New(messages[2])),
-	}
-	for _, err := range addErrs {
-		c.AddError(err)
-	}
-	assert.True(t, c.HasErrors())
-	assert.Len(t, c.Errors, 3)
-	for i, err := range addErrs {
-		assert.Equal(t, err.GetHTTPCode(), c.Errors[i].GetHTTPCode())
-		assert.Equal(t, err.Error(), c.Errors[i].Error())
-	}
 }

--- a/server/core/db/id_gen.go
+++ b/server/core/db/id_gen.go
@@ -5,15 +5,13 @@ import (
 	"letstalk/server/data"
 	"sync"
 
-	"letstalk/server/core/errs"
-
 	"github.com/mijia/modelq/gmq"
 )
 
 var idMutex = sync.Mutex{}
 
 // NumId safely generates a unique numerical id.
-func NumId(c *ctx.Context) int {
+func NumId(c *ctx.Context) (int, error) {
 	idMutex.Lock()
 	defer idMutex.Unlock()
 	var nextId int
@@ -28,8 +26,7 @@ func NumId(c *ctx.Context) int {
 		return err
 	})
 	if err != nil {
-		c.AddError(errs.NewDbError(err))
-		return 0
+		return 0, err
 	}
-	return nextId
+	return nextId, nil
 }

--- a/server/core/login/login_callback_controller.go
+++ b/server/core/login/login_callback_controller.go
@@ -1,6 +1,9 @@
 package login
 
-import "letstalk/server/core/ctx"
+import (
+	"letstalk/server/core/ctx"
+	"letstalk/server/core/errs"
+)
 
 type CallbackResponse struct {
 	Status string
@@ -8,11 +11,12 @@ type CallbackResponse struct {
 	State  string
 }
 
-func GetLoginResponse(c *ctx.Context) {
+func GetLoginResponse(c *ctx.Context) errs.Error {
 	status := c.GinContext.Query("status")
 	code := c.GinContext.Query("code")
 	state := c.GinContext.Query("state")
 
 	// authenticated data from the provider
 	_ = CallbackResponse{status, code, state}
+	return nil
 }

--- a/server/core/login/login_controller.go
+++ b/server/core/login/login_controller.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"letstalk/server/core/ctx"
+	"letstalk/server/core/errs"
 	"letstalk/server/core/secrets"
 	"net/http"
 	"text/template"
@@ -20,7 +21,7 @@ type redirectData struct {
 	CSRFToken   string
 }
 
-func GetLogin(c *ctx.Context) {
+func GetLogin(c *ctx.Context) errs.Error {
 	data := redirectData{
 		AppId:       secrets.GetSecrets().AppId,
 		RedirectUrl: secrets.GetSecrets().RedirectUrl,
@@ -33,4 +34,6 @@ func GetLogin(c *ctx.Context) {
 	fmt.Println(redirectUrl)
 
 	c.GinContext.Redirect(http.StatusSeeOther, redirectUrl)
+
+	return nil
 }

--- a/server/core/routes/test_route.go
+++ b/server/core/routes/test_route.go
@@ -2,9 +2,11 @@ package routes
 
 import (
 	"letstalk/server/core/ctx"
+	"letstalk/server/core/errs"
 )
 
-func GetTest(c *ctx.Context) {
+func GetTest(c *ctx.Context) errs.Error {
 	result := struct{ Response string }{"test controller"}
 	c.Result = result
+	return nil
 }


### PR DESCRIPTION
Handle errors by returning them from the handler function instead of adding them to the context.
I set up the context/errors to behave similarly to what I'm used to, but I realized that our use case is slightly different (in that we should only ever have one error to deal with at a time), and that it was unnecessarily complicated to do it that way.