### PR TITLE
Use camelCase instead of snake_case

### DIFF
--- a/server/core/api/cohort.go
+++ b/server/core/api/cohort.go
@@ -24,7 +24,7 @@ func GetCohortController(c *ctx.Context) errs.Error {
 }
 
 /**
- * Try to see if there is school data assiociated with this account.
+ * Try to see if there is school data associated with this account.
  * If there is no data, return nil
  */
 func GetUserCohort(db *gmq.Db, userId int) (*data.Cohort, error) {

--- a/server/core/api/user.go
+++ b/server/core/api/user.go
@@ -7,15 +7,15 @@ import (
 )
 
 /**
- * Holds all the data that we currently assiociate to a user.
+ * Holds all the data that we currently associate with a user.
  */
 type User struct {
-	FirstName string `json:"first_name" binding:"required"`
-	LastName  string `json:"last_name" binding:"required"`
+	FirstName string `json:"firstName" binding:"required"`
+	LastName  string `json:"lastName" binding:"required"`
 
 	// Contact information
 	Email       string  `json:"email" binding:"required"`
-	PhoneNumber *string `json:"phone_number"`
+	PhoneNumber *string `json:"phoneNumber"`
 
 	// Personal information
 	Gender   string `json:"gender" binding:"required"`

--- a/server/core/login/login_controller.go
+++ b/server/core/login/login_controller.go
@@ -11,7 +11,7 @@ import (
 )
 
 type LoginRequestData struct {
-	UserId   int    `json:"user_id" binding:"required"`
+	UserId   int    `json:"userId" binding:"required"`
 	Password string `json:"password" binding:"required"`
 }
 

--- a/server/core/routes/routes.go
+++ b/server/core/routes/routes.go
@@ -111,11 +111,11 @@ func (hw handlerWrapper) wrapHandler(handler handlerFunc, needAuth bool) gin.Han
 
 		if err != nil {
 			rlog.Infof("Returning error: %s\n", err)
-			c.GinContext.JSON(err.GetHTTPCode(), gin.H{"Error": convertError(err)})
+			c.GinContext.JSON(err.GetHTTPCode(), gin.H{"error": convertError(err)})
 			return
 		}
 		rlog.Infof("Returning result: %s\n", c.Result)
-		c.GinContext.JSON(http.StatusOK, gin.H{"Result": c.Result})
+		c.GinContext.JSON(http.StatusOK, gin.H{"result": c.Result})
 	}
 }
 

--- a/server/core/routes/test_route.go
+++ b/server/core/routes/test_route.go
@@ -6,12 +6,12 @@ import (
 )
 
 func GetTest(c *ctx.Context) errs.Error {
-	result := struct{ Response string }{"test controller"}
+	result := struct{ Response string `json:"response"` }{"test controller"}
 	c.Result = result
 	return nil
 }
 
 func GetTestAuth(c *ctx.Context) errs.Error {
-	c.Result = struct{ Message string }{"test"}
+	c.Result = struct{ Message string `json:"response"` }{"test"}
 	return nil
 }

--- a/server/core/secrets/secrets_manager.go
+++ b/server/core/secrets/secrets_manager.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Secrets struct {
-	AppId       string `json:"app_id"`
-	AppSecret   string `json:"app_secret"`
-	RedirectUrl string `json:"redirect_url"`
+	AppId       string `json:"appId"`
+	AppSecret   string `json:"appSecret"`
+	RedirectUrl string `json:"redirectUrl"`
 }
 
 type SecretsManager struct {


### PR DESCRIPTION
I was going to try to override the json marshaller to always de/serialize json from UpperCamel to lowerCamel, but it seems to not be possible as far as I can tell?

So I guess we just json tag every api struct.