### PR TITLE
Added pages to request a password reset.

### DIFF
--- a/letstalk/src/index.tsx
+++ b/letstalk/src/index.tsx
@@ -30,6 +30,7 @@ import ProfileEditView from './views/ProfileEditView';
 import SignupView from './views/SignupView';
 import OnboardingView from './views/OnboardingView';
 import RequestToMatchView from './views/RequestToMatchView';
+import ForgotPasswordView from './views/ForgotPasswordView';
 import NotificationService, { Notification } from './services/notification-service';
 
 import Colors from './services/colors';
@@ -141,6 +142,9 @@ const createAppNavigation = (loggedIn: boolean) => StackNavigator({
   },
   Signup: {
     screen: SignupView,
+  },
+  ForgotPassword: {
+    screen: ForgotPasswordView,
   },
   Tabbed: {
     screen: createTabView(),

--- a/letstalk/src/services/auth.ts
+++ b/letstalk/src/services/auth.ts
@@ -4,6 +4,7 @@ import { AsyncStorage } from 'react-native';
 
 import requestor from './requests';
 import { SessionService, SessionToken, RemoteSessionService } from './session-service';
+import {FORGOT_PASSWORD_ROUTE} from './constants';
 
 export class Auth {
   private sessionService: SessionService
@@ -49,6 +50,10 @@ export class Auth {
     const sessionToken = await this.getSessionToken();
     AsyncStorage.removeItem(Auth.tokenLocation);
     await this.sessionService.logout(sessionToken);
+  }
+
+  async forgotPassword(email: string): Promise<void> {
+    const resp = await requestor.post(FORGOT_PASSWORD_ROUTE, {"email": email});
   }
 
   async linkFB(): Promise<boolean> {

--- a/letstalk/src/services/constants.ts
+++ b/letstalk/src/services/constants.ts
@@ -1,6 +1,6 @@
 // DEV
 
-export const BASE_URL = 'http://192.168.0.187';
+export const BASE_URL = 'http://192.168.0.10';
 export const ANALYTICS_ID = 'UA-118691527-1';
 // PROD
 // export const BASE_URL = 'http://54.175.152.141';
@@ -12,6 +12,7 @@ export const FB_LOGIN_ROUTE            = '/v1/fb_login';
 export const FB_LINK_ROUTE            = '/v1/fb_link';
 export const LOGIN_ROUTE               = '/v1/login';
 export const LOGOUT_ROUTE              = '/v1/logout';
+export const FORGOT_PASSWORD_ROUTE = '/v1/forgot_password';
 export const MATCH_PROFILE_ROUTE       = '/v1/match_profile';
 export const ME_ROUTE                  = '/v1/me';
 export const PROFILE_PIC_ROUTE         = '/v1/profile_pic';

--- a/letstalk/src/services/requests.ts
+++ b/letstalk/src/services/requests.ts
@@ -45,7 +45,7 @@ export class Requestor {
     if (!response.ok) return response.json().then((data: any) => {
       let errorType: ErrorTypes = 'INVALID_REQUEST';
       if (data.Error.code === 401) errorType = 'UNAUTHORIZED';
-      const e: APIError = { errorMsg: data.Error.errorMsg, errorType };
+      const e: APIError = { errorMsg: data.Error.errorMsg || data.Error.message, errorType };
       throw e;
     });
     const data = await response.json();

--- a/letstalk/src/views/ForgotPasswordView.tsx
+++ b/letstalk/src/views/ForgotPasswordView.tsx
@@ -1,0 +1,113 @@
+import React, {Component} from 'react';
+import { NavigationScreenProp, NavigationStackAction, NavigationActions } from 'react-navigation';
+import { View, StyleSheet } from 'react-native';
+import { reduxForm, Field, InjectedFormProps, SubmissionError } from 'redux-form';
+import { FormValidationMessage, Text } from 'react-native-elements';
+import { ActionButton, FormP, FormProps, LabeledFormInput } from '../components';
+import { KeyboardAvoidingView } from 'react-native';
+import { AnalyticsHelper } from '../services';
+import { infoToast, errorToast } from '../redux/toast';
+import { headerStyle } from './TopHeader';
+import Colors from '../services/colors';
+import { ScrollView } from 'react-native';
+import auth from '../services/auth';
+import { connect, Dispatch } from 'react-redux';
+import { RootState } from '../redux';
+
+interface Props {
+  navigation: NavigationScreenProp<void, NavigationStackAction>;
+  infoToast(message: string): (dispatch: Dispatch<RootState>) => Promise<void>;
+  errorToast(message: string): (dispatch: Dispatch<RootState>) => Promise<void>;
+}
+
+interface ForgotPasswordFormData {
+  email: string,
+}
+
+const required = (value: any) => (value ? undefined : 'Required')
+const email = (value: string) =>
+  value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)
+    ? 'Invalid email address'
+    : undefined;
+const ForgotPasswordForm: React.SFC<FormProps<ForgotPasswordFormData>> = props => {
+  const { error, handleSubmit, onSubmit, reset, submitting, valid, pristine } = props;
+  const onSubmitWithReset = async (values: ForgotPasswordFormData): Promise<void> => {
+    await onSubmit(values);
+  };
+  return (
+    <ScrollView>
+      <Field
+        label="Email"
+        name="email"
+        keyboardType={'email-address' as 'email-address'}
+        component={LabeledFormInput}
+        autoCorrect={false}
+        autoCapitalize={'none' as 'none'}
+        validate={[required, email]}
+      />
+      {error && <FormValidationMessage>{error}</FormValidationMessage>}
+      <ActionButton
+        buttonStyle={{backgroundColor: Colors.HIVE_PRIMARY}}
+        textStyle={{color: Colors.HIVE_MAIN_FONT}}
+        disabled={pristine || !valid}
+        loading={submitting}
+        title={submitting ? null : "Reset Password"}
+        onPress={handleSubmit(onSubmitWithReset)}
+      />
+    </ScrollView>
+  );
+}
+
+const ForgotPasswordFormWithRedux = reduxForm<ForgotPasswordFormData, FormP<ForgotPasswordFormData>>({
+  form: 'forgotPassword',
+})(ForgotPasswordForm);
+
+export class ForgotPasswordView extends Component<Props> {
+  FORGOT_PASSWORD_VIEW_IDENTIFIER = "ForgotPasswordView";
+
+  static navigationOptions = {
+    headerTitle: 'Forgot Password',
+    headerStyle,
+  }
+
+  constructor(props: Props) {
+    super(props);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  async componentDidMount() {
+    AnalyticsHelper.getInstance().recordPage(this.FORGOT_PASSWORD_VIEW_IDENTIFIER);
+  }
+
+  async onSubmit(values: ForgotPasswordFormData) {
+    // TODO submit password reset request
+    try {
+      await auth.forgotPassword(values.email);
+      await this.props.infoToast("Sent an email with reset instructions.");
+      this.props.navigation.dispatch(NavigationActions.reset({
+        index: 0,
+        key: null,
+        actions: [NavigationActions.navigate({ routeName: 'Login' })]
+      }));
+    } catch(e) {
+      await this.props.errorToast(e.errorMsg);
+      throw new SubmissionError({_error: e.errorMsg});
+    }
+}
+
+  render() {
+    return (
+      <KeyboardAvoidingView behavior="padding">
+        <ForgotPasswordFormWithRedux onSubmit={this.onSubmit} />
+      </KeyboardAvoidingView>
+    );
+  }
+}
+
+export default connect(null, {infoToast, errorToast})(ForgotPasswordView);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  }
+});

--- a/letstalk/src/views/LoginView.tsx
+++ b/letstalk/src/views/LoginView.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Button as ReactNativeButton, View, StyleSheet, Platform } from 'react-native';
-import { FormValidationMessage } from 'react-native-elements';
+import { Button as ReactNativeButton, View, StyleSheet, Platform, TouchableOpacity } from 'react-native';
+import { FormValidationMessage, Text } from 'react-native-elements';
 import { reduxForm, Field, SubmissionError } from 'redux-form';
 import {
   NavigationScreenProp,
@@ -203,11 +203,18 @@ export default class LoginView extends Component<Props> {
         onPress={() => this.props.navigation.dispatch(NavigationActions.navigate({routeName: 'Signup'}))} />
       : null;
 
+    const forgotPasswordButton = (
+        <TouchableOpacity onPress={() => this.props.navigation.dispatch(NavigationActions.navigate({routeName: 'ForgotPassword'}))}>
+          <Text style={{ color: Colors.HIVE_PRIMARY, fontSize: 13, paddingTop: 2 }}>Forgot my password</Text>
+        </TouchableOpacity>
+      );
+
     return (
       <View>
         <LoginFormWithRedux onSubmit={this.onSubmit} />
         {signupButton}
         <FBLoginFormWithRedux onSubmit={this.onSubmitFb} />
+        {forgotPasswordButton}
       </View>
     );
   }


### PR DESCRIPTION
New page to do password reset in frontend. Also fix a bug where error messages for non 401's weren't being handled properly (see changes in `requests.ts`).