### PR TITLE
Perform login after signup

### DIFF
--- a/letstalk/src/views/LoginView.tsx
+++ b/letstalk/src/views/LoginView.tsx
@@ -154,36 +154,12 @@ export default class LoginView extends Component<Props> {
     AnalyticsHelper.getInstance().recordPage(this.LOGIN_VIEW_IDENTIFIER);
   }
 
-  async registerForPushNotificationsAsync(): Promise<string> {
-    const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS as any);
-    let finalStatus = existingStatus;
-
-    // only ask if permissions have not already been determined, because
-    // iOS won't necessarily prompt the user a second time.
-    if (existingStatus !== 'granted') {
-      // Android remote notification permissions are granted during the app
-      // install, so this will only ask on iOS
-      const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS as any);
-      finalStatus = status;
-    }
-
-    // Stop here if the user did not grant permissions
-    if (finalStatus !== 'granted') {
-      return;
-    }
-
-    // Get the token that uniquely identifies this device
-    let token = await Notifications.getExpoPushTokenAsync();
-    console.log("Registered with expo notification service: " + token);
-    return token;
-  }
-
   async onSubmitFb() {
     try {
       let token: string = null;
       // don't fail if expo is down
       try {
-        token = await this.registerForPushNotificationsAsync();
+        token = await auth.registerForPushNotificationsAsync();
       } catch(e){
         console.log("Failed to register for notification")
       }
@@ -208,7 +184,7 @@ export default class LoginView extends Component<Props> {
       let token: string = null;
       // don't fail if expo is down
       try {
-        token = await this.registerForPushNotificationsAsync();
+        token = await auth.registerForPushNotificationsAsync();
       } catch(e){
         console.log("Failed to register for notification")
       }

--- a/letstalk/src/views/SignupView.tsx
+++ b/letstalk/src/views/SignupView.tsx
@@ -25,6 +25,7 @@ import photoService, {PhotoResult} from '../services/photo_service';
 import Colors from '../services/colors';
 import {AnalyticsHelper} from '../services/analytics';
 import { headerStyle } from './TopHeader';
+import auth from "../services/auth";
 
 interface SignupFormData {
   firstName: string;
@@ -209,11 +210,23 @@ export default class SignupView extends Component<Props> {
           "birthdate": values.birthdate,
         }
       });
-      // TODO: have a prompt saying successfully signed up
+    } catch(e) {
+      throw new SubmissionError({_error: e.errorMsg});
+    }
+    // TODO: have a prompt saying successfully signed up
+    // Immediately log in.
+    try {
+      let token: string = null;
+      // Don't fail if expo is down
+      try {
+        token = await auth.registerForPushNotificationsAsync();
+      } catch(e){
+        console.log("Failed to register for notifications");
+      }
+      await auth.login(values.email, values.password, token);
       this.props.navigation.dispatch(NavigationActions.reset({
         index: 0,
-        key: null,
-        actions: [NavigationActions.navigate({ routeName: 'Login' })]
+        actions: [NavigationActions.navigate({ routeName: 'Tabbed' })]
       }));
     } catch(e) {
       throw new SubmissionError({_error: e.errorMsg});


### PR DESCRIPTION
After sign up succeeds, perform log in and navigate to main view.