### PR TITLE
Pull session key from db into memory.

### DIFF
--- a/server/core/sessions/database_session_store.go
+++ b/server/core/sessions/database_session_store.go
@@ -31,7 +31,7 @@ func (sm DatabaseSessionStore) AddNewSession(session *SessionData) error {
 		return e
 	}
 
-	if e := tx.Create(sessionModel).Error; e != nil {
+	if e := tx.FirstOrCreate(&sessionModel).Error; e != nil {
 		return e
 	}
 


### PR DESCRIPTION
Update session tokens across all stores if there is a faster store that doesn't have the key.