### PR TITLE
Added helper to get elastic search api instance.

### DIFF
--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -15,7 +15,7 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:dd90f0d41fb8c7676592a38e37be23a8a4fa011e62c0f3403b1a56efb28b8bfc"
+  digest = "1:8c99ab26d85eaab2284257d2590f63cbefda36eefd9165d6a5b36a21562bd81f"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -46,6 +46,7 @@
     "private/protocol/restjson",
     "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
+    "service/elasticsearchservice",
     "service/lambda",
     "service/s3",
     "service/s3/s3iface",
@@ -358,6 +359,7 @@
     "github.com/aws/aws-sdk-go/aws/credentials",
     "github.com/aws/aws-sdk-go/aws/endpoints",
     "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/elasticsearchservice",
     "github.com/aws/aws-sdk-go/service/lambda",
     "github.com/aws/aws-sdk-go/service/s3",
     "github.com/aws/aws-sdk-go/service/s3/s3manager",

--- a/server/aws_utils/helper.go
+++ b/server/aws_utils/helper.go
@@ -1,15 +1,17 @@
 package aws_utils
 
 import (
+	"letstalk/server/core/secrets"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"letstalk/server/core/secrets"
 )
 
 func getDefaultConfiguration() *aws.Config {
@@ -88,4 +90,13 @@ func GetS3ServiceClient() (*s3.S3, error) {
 	s3Client := s3.New(sess, config)
 
 	return s3Client, nil
+}
+
+func GetElasticSearchClient() (*elasticsearchservice.ElasticsearchService, error) {
+	sess, err := getDefaultSession()
+	if err != nil {
+		return nil, err
+	}
+	esClient := elasticsearchservice.New(sess)
+	return esClient, nil
 }


### PR DESCRIPTION
For the future search functionality. Gets an object to interact with elastic search. If you want to test, we need to run this code from the prod server on aws. 