### PR TITLE
Send each notification individually

### DIFF
--- a/server/data/notification.go
+++ b/server/data/notification.go
@@ -76,6 +76,21 @@ func NotificationSentToExpoDevice(db *gorm.DB, notificationId uint, deviceId str
 	return true, nil
 }
 
+func ExistsPendingNotification(db *gorm.DB, notificationId uint, deviceId string) (bool, error) {
+	notification := ExpoPendingNotification{
+		NotificationId: notificationId,
+		DeviceId:       deviceId,
+	}
+	var res ExpoPendingNotification
+	if err := db.Where(&notification).First(&res).Error; err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func CreateNewPendingNotification(db *gorm.DB, notificationId uint, deviceId string) (*ExpoPendingNotification, error) {
 	notification := ExpoPendingNotification{
 		NotificationId: notificationId,


### PR DESCRIPTION
Bug with sending messages where if the Expo token was from different expo projects (i.e. mine and wojteks different projects) a single batch api call would fail for one set of device tokens.

For example, 
device1 is andrews app -> get token 1
device 2 is wojteks app -> get token 2

send batch notification to device 1 and 2 in single api call
device 2 would fail


On top of this I also try to make notifications more idempotent so that we don't resend ones already sent.