### PR TITLE
ssh Relay to get around bad networks

### DIFF
--- a/relay.sh
+++ b/relay.sh
@@ -8,8 +8,8 @@
 # set in the /etc/ssh/sshd_config
 
 
-read -p "Enter username: " username
-read -p "Enter port to forward to: " port
+read -p "Enter username to use for ssh: " username
+read -p "Enter local port to forward: " port
 ssh -g -R 10123:localhost:$port $username@hiveapp.org
 
 echo "Now you can access your port $port at hiveapp.org:10123! MAKE SURE TO KEEP THIS CONNECTION OPEN"


### PR DESCRIPTION
Create a relay through ssh. This makes the local port on your computer accessible through hiveapp.org:10123.