### PR TITLE
Fix autocomplete android.

### DIFF
--- a/letstalk/src/components/AutocompleteInput.tsx
+++ b/letstalk/src/components/AutocompleteInput.tsx
@@ -196,7 +196,6 @@ const styles = StyleSheet.create({
     margin: 10,
     marginBottom: 5,
     height: 40,
-    zIndex: 1,
   },
   itemContainer: {
     padding: 10,


### PR DESCRIPTION
Having another parent container at the same zlevel was hiding the list.