### PR TITLE
Update toast stylings

### DIFF
--- a/letstalk/src/index.tsx
+++ b/letstalk/src/index.tsx
@@ -80,6 +80,12 @@ const styles = StyleSheet.create({
   toastMessageStyle: {
     color: 'white',
   },
+  toastContainerStyle: {
+    backgroundColor: Colors.HIVE_PRIMARY,
+  },
+  toastErrorStyle: {
+    backgroundColor: Colors.HIVE_ERROR,
+  },
 });
 
 interface TabBarState {
@@ -305,7 +311,10 @@ class App extends React.Component<Props, AppState> {
             ref={(ref: any) => this.notificationService.setNotifContainer(ref)}
             notificationBodyComponent={ NotificationBody }
           />
-          <Toast messageStyle={styles.toastMessageStyle} />
+          <Toast
+            containerStyle={styles.toastContainerStyle}
+            messageStyle={styles.toastMessageStyle}
+            errorStyle={styles.toastErrorStyle} />
         </View>
       </Provider>
     );


### PR DESCRIPTION
Update info and error toast backgrounds to Hive Primary and Hive Error colours:
<div style="inline-block">
<img src="https://user-images.githubusercontent.com/3172103/46590176-56293a80-ca7f-11e8-98dd-bc2399b71439.png" width="300" />
<img src="https://user-images.githubusercontent.com/3172103/46590177-56293a80-ca7f-11e8-8b4b-27d6fa61dd3f.png" width="300" />
</div>
