### PR TITLE
Docker modularization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,4 @@
-FROM ubuntu:18.04
-MAINTAINER Andrew Codispoti
-
-RUN apt-get update --fix-missing -y
-RUN apt-get install -y vim curl golang git python3 jq
-
-# gopath in root
-ENV GOPATH /go
-ENV PATH="${PATH}:/go/bin"
-
-# gin to run reloading server
-RUN go get github.com/codegangsta/gin
-
-# add the source code
-# currently this is handled by the docker run command
-ADD ./server /go/src/letstalk/server
-
-# install dep
-RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-
-# set the working directory
-WORKDIR /go/src/letstalk/server
-RUN dep ensure
-
-# fetch dependencies
-ENV SECRETS_PATH secrets.json
+# Run the app in the environment
+FROM letstalk_env as app
 CMD ./run_remote.sh
 EXPOSE 3000

--- a/Dockerfile.env
+++ b/Dockerfile.env
@@ -1,0 +1,29 @@
+# THIS IS COMMON BETWEEN PROD AND DEBUG
+
+# Create the environment needed for the application
+FROM ubuntu:18.04 as env
+MAINTAINER Andrew Codispoti
+
+RUN apt-get update --fix-missing -y
+RUN apt-get install -y vim curl golang git python3 jq
+
+# gopath in root
+ENV GOPATH /go
+ENV PATH="${PATH}:/go/bin"
+
+# gin to run reloading server
+RUN go get github.com/codegangsta/gin
+
+# add the source code
+# currently this is handled by the docker run command
+ADD ./server /go/src/letstalk/server
+
+# install dep
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+# set the working directory
+WORKDIR /go/src/letstalk/server
+RUN dep ensure
+
+# fetch dependencies
+ENV SECRETS_PATH secrets.json

--- a/README.md
+++ b/README.md
@@ -88,3 +88,10 @@ Run the following command on ec2 server.
 ```
 ./prod.sh
 ```
+
+# Dockerfile Architecture
+There are 2 docker files: one base which contains the build environment needed
+to build the application and one to build a the actual application image.
+
+- `Dockerfile.env`: All dependencies needed to build the application
+- `Dockerfile`: Default used to build image 

--- a/dev.sh
+++ b/dev.sh
@@ -5,4 +5,4 @@
 # setup latest git hooks
 cp hooks/* .git/hooks
 
-docker-compose -f 'docker-compose.yml' -f 'docker-compose-debug.yml' up
+docker-compose -f 'docker-compose.yml' -f 'docker-compose-debug.yml' up --build

--- a/docker-compose-debug.yml
+++ b/docker-compose-debug.yml
@@ -9,6 +9,7 @@ services:
     depends_on:
       - db
       - elasticsearch
+      - env
     networks:
       - db_net
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,12 @@ services:
       - "3000"
     networks:
       - lb_net
+    depends_on:
+      - env
+  env:
+    build:
+      context: .
+      dockerfile: Dockerfile.env
 
 networks:
   lb_net:


### PR DESCRIPTION
This change introduces a refactoring of how we run docker at Hive.

The main change is a separation of the setup of the build environment into its own docker file (see `Dockerfile.env`).

The reason for these changes is so that we can have an image with all of the environment that can be instantiated as a container so commands can be run using a command like `docker run -it <YOUR COMMAND>`. Commands run like that will be run identically to the main application but will be isolated from the production application container. This makes it possible to run go scripts on the actual production server without impacting our application.