### PR TITLE
Rename queue helpers

### DIFF
--- a/server/core/main.go
+++ b/server/core/main.go
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	// setup queue listeners for local delivery
-	sqs := utility.QueueHelper.(utility.SQSMock)
+	sqs := utility.QueueHelper.(utility.LocalQueueImpl)
 	go sqs.QueueProcessor()
 	sqs.SubscribeListener(constants.NotificationQueueUrl, func(event *events.SQSEvent) error {
 		if err := sqs_notification_processor.SendNotificationLambda(*event); err != nil {

--- a/server/jobs/task_runner/main.go
+++ b/server/jobs/task_runner/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	rlog.Debugf("Queue processing")
 	// process anything in the sqs queue
-	if helper, ok := utility.QueueHelper.(utility.SQSMock); ok {
+	if helper, ok := utility.QueueHelper.(utility.LocalQueueImpl); ok {
 		helper.SubscribeListener(constants.NotificationQueueUrl, func(event *events.SQSEvent) error {
 			if err := sqs_notification_processor.SendNotificationLambda(*event); err != nil {
 				rlog.Critical(err)

--- a/server/utility/common.go
+++ b/server/utility/common.go
@@ -39,7 +39,7 @@ func Bootstrap() {
 	secrets.LoadSecrets(*secretsPath)
 
 	// Setup a worker to process all messages sent to a queue.
-	QueueHelper = CreateMockSQSClient()
+	QueueHelper = CreateLocalSQSClient()
 }
 
 func checkBootstrapped() {


### PR DESCRIPTION
Rename queue helpers to say that it is local (and isn't exclusively a mock).