### PR TITLE
Made long test look better on change cohort on ios

### DIFF
--- a/letstalk/src/components/BottomModal.tsx
+++ b/letstalk/src/components/BottomModal.tsx
@@ -53,11 +53,16 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 
+  topLeftLabel: {
+    fontWeight: 'bold',
+    fontSize: 14,
+  },
+
   valueLabel: {
     fontSize: 18,
-    textAlign: 'center',
     color: 'gray',
-    paddingLeft: 10,
+    flex: 1,
+    flexWrap: 'wrap',
   },
 
   cardWithValue: {
@@ -67,7 +72,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     height: 60,
     padding: 10,
-    paddingLeft: 20,
+    paddingHorizontal: 20,
   },
 
   cardWithoutValue: {
@@ -135,17 +140,17 @@ class StatefulBottomModal extends Component<Props, State> {
     });
   }
 
-  renderDisplayWithValue() {
+  private renderDisplayWithValue() {
     const { valueLabel, label } = this.props;
     return (
-      <View style={styles.inlineLabel}>
-        <Text style={styles.label}>{label}</Text>
+      <View>
+        <Text style={styles.topLeftLabel}>{label}</Text>
         <Text style={styles.valueLabel}>{valueLabel}</Text>
       </View>
     );
   }
 
-  renderDisplayWithoutValue() {
+  private renderDisplayWithoutValue() {
     const { label } = this.props;
     return (
         <Text style={styles.label}>{label}</Text>

--- a/letstalk/src/components/ModalPicker.tsx
+++ b/letstalk/src/components/ModalPicker.tsx
@@ -8,7 +8,7 @@ import {
   PickerIOS,
   PickerProperties,
   Platform,
-  StyleProp, 
+  StyleProp,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -21,6 +21,7 @@ import { FormValidationMessage } from 'react-native-elements';
 import RNPickerSelect from 'react-native-picker-select';
 
 import BottomModal from './BottomModal';
+import Colors from '../services/colors';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -97,7 +98,13 @@ class StatefulModalPicker extends Component<Props, State> {
       ),
       'android': (
         <View style={this.props.containerStyle}>
-          <RNPickerSelect placeholder={{label: label, value: null}} items={items} onValueChange={onChange} value={value} />
+          <RNPickerSelect
+            placeholder={{label: label, value: null}}
+            placeholderTextColor={Colors.DARK_GRAY}
+            items={items}
+            onValueChange={onChange}
+            value={value}
+          />
           {touched && (
             (error && <FormValidationMessage>{error}</FormValidationMessage>) ||
             (warning && <FormValidationMessage>{warning}</FormValidationMessage>))}


### PR DESCRIPTION
Fixed the way the buttons look on ios:
![image](https://user-images.githubusercontent.com/6377160/50864243-5df2c680-136f-11e9-8ff5-a971351e70a8.png)
Also, on Android, made the colour for the cohort dropdowns grey when only the placeholder is shown