### PR TITLE
Added padding to user search autocomplete results

### DIFF
--- a/letstalk/src/views/user-search/UserSearchAutocompleteModal.tsx
+++ b/letstalk/src/views/user-search/UserSearchAutocompleteModal.tsx
@@ -277,6 +277,7 @@ const styles = StyleSheet.create({
   },
   traitContainer: {
     paddingLeft: 10,
+    paddingRight: 20,
   },
   traitText: {
     fontSize: 16,


### PR DESCRIPTION
Added some padding to fix the overflow that was happening with user search autocomplete results.

Before:
![image](https://user-images.githubusercontent.com/6377160/51151018-f937e000-1836-11e9-8b1f-1537ee90aa68.png)

After:
![image](https://user-images.githubusercontent.com/6377160/51151025-ffc65780-1836-11e9-9460-02b20dfad8af.png)
