### PR TITLE
Fix Notification vs Onboarding Navigation Race

### DIFF
--- a/letstalk/src/services/constants.ts
+++ b/letstalk/src/services/constants.ts
@@ -1,7 +1,7 @@
 // DEV
 
 export const BASE_URL = 'https://api.hiveapp.org';
-// export const BASE_URL = 'http://192.168.0.21';
+// export const BASE_URL = 'http://10.220.67.54';
 export const ANALYTICS_ID = 'UA-118691527-1';
 
 // Routes


### PR DESCRIPTION
There's an edge case where if someone hasn't completed onboarding but gets a notification and they open it, they won't actually see the notification (onboarding steps override). Thus, we only open onboarding steps if the HomeView is focused when bootstrap is loaded.