### PR TITLE
Heap based implementation for greedy upper/lower year matcher

### DIFF
--- a/server/recommendations/matcher_greedy_upper_lower_year.go
+++ b/server/recommendations/matcher_greedy_upper_lower_year.go
@@ -1,15 +1,51 @@
 package recommendations
 
 import (
-	"sort"
+	"container/heap"
 
 	"letstalk/server/data"
 )
 
+type UserMatchesPQ []UserMatch
+
+func (pq UserMatchesPQ) Len() int {
+	return len(pq)
+}
+
+func (pq UserMatchesPQ) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return pq[i].Score > pq[j].Score
+}
+
+func (pq UserMatchesPQ) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *UserMatchesPQ) Push(x interface{}) {
+	*pq = append(*pq, x.(UserMatch))
+}
+
+func (pq *UserMatchesPQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	match := old[n-1]
+	*pq = old[0 : n-1]
+	return match
+}
+
+// Returns a "set" of all user ids from given list of users.
+func getUserIdSet(users []data.User) map[data.TUserID]interface{} {
+	userIdSet := make(map[data.TUserID]interface{})
+	for _, user := range users {
+		userIdSet[user.UserId] = nil
+	}
+	return userIdSet
+}
+
 type GreedyUpperLowerYearMatcher struct {
-	MaxLowerYears     uint // Maximum number of lower-years per upper-year
-	MaxUpperYears     uint // Maximum number of upper-years per lower-year
-	YoungestUpperYear uint // Graduating year of "youngest" upper-year
+	MaxLowerYearsPerUpperYear uint // Maximum number of lower-years per upper-year
+	MaxUpperYearsPerLowerYear uint // Maximum number of upper-years per lower-year
+	YoungestUpperYear         uint // Graduating year of "youngest" upper-year
 }
 
 func (m GreedyUpperLowerYearMatcher) RequiredObjects() []string {
@@ -36,35 +72,10 @@ func (m GreedyUpperLowerYearMatcher) splitUsersByGradYear(
 	return lowerYears, upperYears
 }
 
-// Returns a sorted list of lower year ids based on the current match we are looking at for each
-// lower year. If we've ran out of candidates for a lower year, we don't include them in the
-// returned list.
-// lowerYearIterIdxs - indexes into matchMap for the current upper year we are considering for a
-// match.
-// matchMap - list from lower year user id to list of potential matches for that lower year.
-func lowerYearsOrderedByDecreasingBestScore(
-	lowerYearIterIdxs map[data.TUserID]uint,
-	matchMap map[data.TUserID][]UserMatch,
-) []data.TUserID {
-	matchesToSort := make([]UserMatch, 0)
-
-	for lowerYearId := range lowerYearIterIdxs {
-		idx := lowerYearIterIdxs[lowerYearId]
-		if idx < uint(len(matchMap[lowerYearId])) {
-			matchesToSort = append(matchesToSort, matchMap[lowerYearId][idx])
-		}
-	}
-
-	sort.Sort(byScore(matchesToSort))
-
-	sortedLowerYearsIds := make([]data.TUserID, len(matchesToSort))
-	for i, match := range matchesToSort {
-		sortedLowerYearsIds[i] = match.UserOneId
-	}
-
-	return sortedLowerYearsIds
-}
-
+// Matches users in lower year cohorts to users in upper year cohorts greedily
+// We essentially choose the highest scoring matches first.
+// Some amount of fairness is maintained by the fact that we make sure that each lower year has
+// a match before we give any lower year their next match. Thus, the matching is done in epochs.
 func (m GreedyUpperLowerYearMatcher) Match(
 	users []data.User,
 	score PairwiseScore,
@@ -77,36 +88,48 @@ func (m GreedyUpperLowerYearMatcher) Match(
 
 	var (
 		matches            = make([]UserMatch, 0)        // list containing matches
-		lowerYearIterIdxs  = make(map[data.TUserID]uint) // keep track of match iter idxs per lower year
-		upperYearMatchCnts = make(map[data.TUserID]uint) // keep track of match count per upper year
+		upperYearMatchCnts = make(map[data.TUserID]uint) // number of matches made per upper year
+		matchCandidateHeap = make(UserMatchesPQ, 0)      // pq of matches by decreasing score
 	)
 
-	for _, lowerYear := range lowerYears {
-		lowerYearIterIdxs[lowerYear.UserId] = 0
+	// Init heap with all matches
+	for _, match := range matchMap {
+		matchCandidateHeap = append(matchCandidateHeap, match)
 	}
+	heap.Init(&matchCandidateHeap)
+
+	// Init all upper year match counts to 0
 	for _, upperYear := range upperYears {
 		upperYearMatchCnts[upperYear.UserId] = 0
 	}
 
-	// Try up to MaxUpperYears matches for each lower year.
-	// We go one match at a time for each lower year to make it more fair for lower years that don't
-	// have as many "compatible" upper years. Still want to give them decent matches.
-	for matchRun := uint(0); matchRun < m.MaxUpperYears; matchRun++ {
-		lowerYearIds := lowerYearsOrderedByDecreasingBestScore(lowerYearIterIdxs, matchMap)
-		for _, lowerYearId := range lowerYearIds {
-			iterIdx := lowerYearIterIdxs[lowerYearId]
-			lowerYearMatches := matchMap[lowerYearId]
-			for iterIdx < uint(len(lowerYearMatches)) {
-				match := lowerYearMatches[iterIdx]
-				iterIdx++
-				if upperYearMatchCnts[match.UserTwoId] < m.MaxLowerYears {
-					// Upper year still has capacity, add this match
+	// Each "epoch" attempts to find 1 match for each lower year, attempting to perserve some level
+	// of "fairness" during matching.
+	for matchRun := uint(0); matchRun < m.MaxUpperYearsPerLowerYear; matchRun++ {
+		lowerYearsToMatch := getUserIdSet(lowerYears)
+		skippedMatches := make([]UserMatch, 0)
+
+		for len(lowerYearsToMatch) > 0 && len(matchCandidateHeap) > 0 {
+			match := heap.Pop(&matchCandidateHeap).(UserMatch)
+			_, lowerYearNotMatched := lowerYearsToMatch[match.UserOneId]
+			upperYearHasCapacity := upperYearMatchCnts[match.UserTwoId] < m.MaxLowerYearsPerUpperYear
+
+			if upperYearHasCapacity {
+				if lowerYearNotMatched {
+					delete(lowerYearsToMatch, match.UserOneId)
 					matches = append(matches, match)
 					upperYearMatchCnts[match.UserTwoId]++
-					break
+				} else {
+					// Lower year is already matched for this round, but upper year still has capacity, so
+					// we want to place it back on heap for next round.
+					skippedMatches = append(skippedMatches, match)
 				}
 			}
-			lowerYearIterIdxs[lowerYearId] = iterIdx
+		}
+
+		// Place any skipped matches back on heap
+		for _, match := range skippedMatches {
+			heap.Push(&matchCandidateHeap, match)
 		}
 	}
 

--- a/server/recommendations/matcher_helper.go
+++ b/server/recommendations/matcher_helper.go
@@ -1,37 +1,18 @@
 package recommendations
 
-import (
-	"sort"
-
-	"letstalk/server/data"
-)
-
-type byScore []UserMatch
-
-func (a byScore) Len() int {
-	return len(a)
-}
-
-func (a byScore) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-func (a byScore) Less(i, j int) bool {
-	// Sort by decreasing
-	return a[i].Score > a[j].Score
-}
+import "letstalk/server/data"
 
 // Calculates all user matches by taking the product of two lists of users.
 // Will return m * n user matches given m users on the left and n users on the right.
-// Map is keyed by user ids of left users, and each list is sorted by decreasing score.
+// Returns a list of all of these matches. userOneId will be users from the left list and userTwoId
+// will be users from the right list. Matches are unsorted
 func calculateSplitUserMatches(
 	usersLeft []data.User,
 	usersRight []data.User,
 	score PairwiseScore,
-) (map[data.TUserID][]UserMatch, error) {
-	matches := make(map[data.TUserID][]UserMatch)
+) ([]UserMatch, error) {
+	matches := make([]UserMatch, 0)
 	for _, userLeft := range usersLeft {
-		matches[userLeft.UserId] = make([]UserMatch, 0, len(usersRight))
 		for _, userRight := range usersRight {
 			// Don't create matches for two of the same user
 			if userLeft.UserId != userRight.UserId {
@@ -44,11 +25,9 @@ func calculateSplitUserMatches(
 					UserTwoId: userRight.UserId,
 					Score:     value,
 				}
-				matches[userLeft.UserId] = append(matches[userLeft.UserId], userMatch)
+				matches = append(matches, userMatch)
 			}
 		}
-		// Sort matches by decreasing score
-		sort.Sort(byScore(matches[userLeft.UserId]))
 	}
 	return matches, nil
 }


### PR DESCRIPTION
As mentioned in https://github.com/andrew749/letstalk/pull/325#discussion_r249797708, there was an issue with the old implementation where we would skip potentially better matches when the upper year user for a particular match was already at capacity. This implementation solves that issue.