### PR TITLE
Jobmine better running granularity

### DIFF
--- a/server/core/test_light/testing_utils.go
+++ b/server/core/test_light/testing_utils.go
@@ -17,6 +17,12 @@ type Test struct {
 	TestName string
 }
 
+// DB flags
+var (
+	databasePrefix = uuid.New().String()
+	dbPath         = fmt.Sprintf("/tmp/%s.db", databasePrefix)
+)
+
 func createFileIfNotExists(path string) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -26,7 +32,7 @@ func createFileIfNotExists(path string) error {
 	return nil
 }
 
-func GetSqliteDB(dbPath string) (*gorm.DB, error) {
+func GetSqliteDB() (*gorm.DB, error) {
 	if err := createFileIfNotExists(dbPath); err != nil {
 		return nil, err
 	}
@@ -38,7 +44,7 @@ func GetSqliteDB(dbPath string) (*gorm.DB, error) {
 	return db, err
 }
 
-func TearDownLocalDatabase(dbPath string) {
+func TearDownLocalDatabase() {
 	os.Remove(dbPath)
 }
 
@@ -48,11 +54,8 @@ type DatabaseAwareFunc func(*gorm.DB) error
 func RunTestsWithDb(provisionDatabase DatabaseAwareFunc, tests []Test) {
 	var db *gorm.DB
 	var err error
-	databasePrefix := uuid.New().String()
-
-	dbPath := fmt.Sprintf("/tmp/%s.db", databasePrefix)
-	TearDownLocalDatabase(dbPath)
-	if db, err = GetSqliteDB(dbPath); err != nil {
+	TearDownLocalDatabase()
+	if db, err = GetSqliteDB(); err != nil {
 		rlog.Errorf("Failed to create db %s", err.Error())
 		panic(err)
 	}
@@ -68,7 +71,7 @@ func RunTestsWithDb(provisionDatabase DatabaseAwareFunc, tests []Test) {
 		runTestWithDb(db, test)
 	}
 
-	TearDownLocalDatabase(dbPath)
+	TearDownLocalDatabase()
 }
 
 func RunTestWithDb(databaseProvision DatabaseAwareFunc, test Test) {

--- a/server/core/test_light/testing_utils.go
+++ b/server/core/test_light/testing_utils.go
@@ -17,12 +17,6 @@ type Test struct {
 	TestName string
 }
 
-// DB flags
-var (
-	databasePrefix = uuid.New().String()
-	dbPath         = fmt.Sprintf("/tmp/%s.db", databasePrefix)
-)
-
 func createFileIfNotExists(path string) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -32,7 +26,7 @@ func createFileIfNotExists(path string) error {
 	return nil
 }
 
-func GetSqliteDB() (*gorm.DB, error) {
+func GetSqliteDB(dbPath string) (*gorm.DB, error) {
 	if err := createFileIfNotExists(dbPath); err != nil {
 		return nil, err
 	}
@@ -44,7 +38,7 @@ func GetSqliteDB() (*gorm.DB, error) {
 	return db, err
 }
 
-func TearDownLocalDatabase() {
+func TearDownLocalDatabase(dbPath string) {
 	os.Remove(dbPath)
 }
 
@@ -54,8 +48,11 @@ type DatabaseAwareFunc func(*gorm.DB) error
 func RunTestsWithDb(provisionDatabase DatabaseAwareFunc, tests []Test) {
 	var db *gorm.DB
 	var err error
-	TearDownLocalDatabase()
-	if db, err = GetSqliteDB(); err != nil {
+	databasePrefix := uuid.New().String()
+
+	dbPath := fmt.Sprintf("/tmp/%s.db", databasePrefix)
+	TearDownLocalDatabase(dbPath)
+	if db, err = GetSqliteDB(dbPath); err != nil {
 		rlog.Errorf("Failed to create db %s", err.Error())
 		panic(err)
 	}
@@ -71,7 +68,7 @@ func RunTestsWithDb(provisionDatabase DatabaseAwareFunc, tests []Test) {
 		runTestWithDb(db, test)
 	}
 
-	TearDownLocalDatabase()
+	TearDownLocalDatabase(dbPath)
 }
 
 func RunTestWithDb(databaseProvision DatabaseAwareFunc, test Test) {

--- a/server/jobmine/job_integration_test.go
+++ b/server/jobmine/job_integration_test.go
@@ -25,99 +25,302 @@ func provisionDb(db *gorm.DB) error {
 	return nil
 }
 
+const (
+	testJobType  JobType = "Test Job"
+	testJobType2 JobType = "Test Job 2"
+)
+
+func createTestJob(db *gorm.DB, runId string, jobType JobType) (*JobRecord, error) {
+	return CreateJobRecord(
+		db,
+		runId,
+		jobType,
+		map[string]interface{}{},
+		nil,
+	)
+}
+
+func createTestTask(db *gorm.DB, jobId uint, runId string, jobType JobType) (*TaskRecord, error) {
+	return CreateTaskRecord(
+		db,
+		jobId,
+		runId,
+		jobType,
+		map[string]interface{}{},
+	)
+}
+
+func resetDB(db *gorm.DB) {
+	// HACK: we need a hard delete so that the primary key doesn't conflict with new inserted records.
+	if err := db.Exec("DELETE FROM job_records;").Error; err != nil {
+		panic(err)
+	}
+
+	if err := db.Exec("DELETE FROM task_records;").Error; err != nil {
+		panic(err)
+	}
+}
+
 func TestJobIntegration(t *testing.T) {
-	test_light.RunTestWithDb(
+	test_light.RunTestsWithDb(
 		provisionDb,
-		test_light.Test{
-			TestName: "Schedule And run Job Success test",
-			Test: func(db *gorm.DB) {
-				// create job
-				const testJobType JobType = "Test Job"
-				const testRunId = "Test Run 1"
-				now := time.Now()
-				job := JobRecord{
-					Status:  STATUS_CREATED,
-					JobType: testJobType,
-					RunId:   testRunId,
-					Metadata: Metadata(map[string]interface{}{
-						"job_key1": "job_value1",
-					}),
-					StartTime: now.AddDate(0, -1, 0), // yesterday
-				}
-				// schedule job
-				err := db.Create(&job).Error
-				assert.NoError(t, err)
+		[]test_light.Test{
+			test_light.Test{
+				TestName: "Schedule And run Job Success test",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
 
-				var queryJob JobRecord
-				err = db.Where("run_id = ?", testRunId).Find(&queryJob).Error
-				assert.NoError(t, err)
-				assert.NotZero(t, queryJob.ID)
-				assert.Equal(t, STATUS_CREATED, queryJob.Status)
-				rlog.Info("Created job")
+					// create job
+					const testRunId = "Test Run 1"
+					now := time.Now()
+					yesterday := now.AddDate(0, -1, 0) // yesterday
 
-				// define a test job
-				specStore := JobSpecStore{
-					JobSpecs: map[JobType]JobSpec{
-						testJobType: JobSpec{
-							JobType: testJobType,
-							TaskSpec: TaskSpec{
-								Execute: func(db *gorm.DB, jobRecord JobRecord, taskRecord TaskRecord) (interface{}, error) {
-									assert.Equal(t, jobRecord.Status, STATUS_RUNNING)
-									assert.Equal(t, jobRecord.JobType, testJobType)
-									assert.Equal(t, jobRecord.RunId, testRunId)
-									assert.Equal(t, jobRecord.Metadata["job_key1"], "job_value1")
-									assert.Equal(t, taskRecord.JobId, jobRecord.ID)
-									// HACK: the update times are slightly, off; this isnt an issue.
-									now := time.Now()
-									jobRecord.UpdatedAt = now
-									taskRecord.Job.UpdatedAt = now
-									assert.Equal(t, jobRecord, taskRecord.Job)
-									assert.Equal(t, taskRecord.Status, STATUS_RUNNING)
-									assert.Equal(t, taskRecord.Metadata["task_key1"], "task_value1")
-									return "result_task1", nil
+					// define a test job
+					specStore := JobSpecStore{
+						JobSpecs: map[JobType]JobSpec{
+							testJobType: JobSpec{
+								JobType: testJobType,
+								TaskSpec: TaskSpec{
+									Execute: func(db *gorm.DB, jobRecord JobRecord, taskRecord TaskRecord) (interface{}, error) {
+										assert.Equal(t, jobRecord.Status, STATUS_RUNNING)
+										assert.Equal(t, jobRecord.JobType, testJobType)
+										assert.Equal(t, jobRecord.RunId, testRunId)
+										assert.Equal(t, jobRecord.Metadata["job_key1"], "job_value1")
+										assert.Equal(t, taskRecord.JobId, jobRecord.ID)
+										// HACK: the update times are slightly, off; this isnt an issue.
+										now := time.Now()
+										jobRecord.UpdatedAt = now
+										taskRecord.Job.UpdatedAt = now
+										assert.Equal(t, jobRecord, taskRecord.Job)
+										assert.Equal(t, taskRecord.Status, STATUS_RUNNING)
+										assert.Equal(t, taskRecord.Metadata["task_key1"], "task_value1")
+										return "result_task1", nil
+									},
+									OnError: func(db *gorm.DB, jobRecord JobRecord, taskRecord TaskRecord, err error) {
+										assert.Fail(t, "Should not have an error")
+									},
+									OnSuccess: func(db *gorm.DB, jobRecord JobRecord, taskRecord TaskRecord, res interface{}) {
+										assert.Equal(t, res.(string), "result_task1")
+									},
 								},
-								OnError: func(db *gorm.DB, jobRecord JobRecord, taskRecord TaskRecord, err error) {
-									assert.Fail(t, "Should not have an error")
+								GetTasksToCreate: func(db *gorm.DB, jobRecord JobRecord) ([]Metadata, error) {
+									metadata := Metadata(map[string]interface{}{
+										"task_key1": "task_value1",
+									})
+									return []Metadata{metadata}, nil
 								},
-								OnSuccess: func(db *gorm.DB, jobRecord JobRecord, taskRecord TaskRecord, res interface{}) {
-									assert.Equal(t, res.(string), "result_task1")
-								},
-							},
-							GetTasksToCreate: func(db *gorm.DB, jobRecord JobRecord) ([]Metadata, error) {
-								metadata := Metadata(map[string]interface{}{
-									"task_key1": "task_value1",
-								})
-								return []Metadata{metadata}, nil
 							},
 						},
-					},
-				}
+					}
+					job, err := CreateJobRecord(
+						db,
+						testRunId,
+						testJobType,
+						Metadata(map[string]interface{}{
+							"job_key1": "job_value1",
+						}),
+						&yesterday,
+					)
+					assert.NoError(t, err)
 
-				// schedule tasks
-				err = JobRunner(specStore, db)
-				assert.NoError(t, err)
+					var queryJob JobRecord
+					err = db.Where("run_id = ?", testRunId).Find(&queryJob).Error
+					assert.NoError(t, err)
+					assert.NotZero(t, queryJob.ID)
+					assert.Equal(t, STATUS_CREATED, queryJob.Status)
+					rlog.Info("Created job")
 
-				// run tasks
-				err = TaskRunner(specStore, db)
-				assert.NoError(t, err)
+					// schedule tasks
+					err = JobRunner(specStore, db, nil, nil)
+					assert.NoError(t, err)
 
-				// update the state of all tasks
-				err = JobStateWatcher(db)
-				assert.NoError(t, err)
+					// run tasks
+					err = TaskRunner(specStore, db, nil, nil)
+					assert.NoError(t, err)
 
-				// check the state of all jobs
-				err = db.Where("run_id = ?", queryJob.RunId).First(&queryJob).Error
-				assert.NoError(t, err)
-				assert.Equal(t, queryJob.Status, STATUS_SUCCESS)
+					// update the state of all tasks
+					err = JobStateWatcher(db)
+					assert.NoError(t, err)
 
-				// check the state of tasks
-				var queryTask TaskRecord
-				err = db.Where(&TaskRecord{JobId: job.ID}).First(&queryTask).Error
-				assert.NoError(t, err)
-				assert.Equal(t, STATUS_SUCCESS, queryTask.Status)
+					// check the state of all jobs
+					err = db.Where("run_id = ?", queryJob.RunId).First(&queryJob).Error
+					assert.NoError(t, err)
+					assert.Equal(t, queryJob.Status, STATUS_SUCCESS)
 
-				// DONE
+					// check the state of tasks
+					var queryTask TaskRecord
+					err = db.Where(&TaskRecord{JobId: job.ID}).First(&queryTask).Error
+					assert.NoError(t, err)
+					assert.Equal(t, STATUS_SUCCESS, queryTask.Status)
+					resetDB(db)
+
+					// DONE
+				},
 			},
 		},
 	)
+}
+
+const (
+	runId1 = "job 1"
+	runId2 = "job 2"
+	runId3 = "job 3"
+)
+
+func TestGetJobmineJobToRun(t *testing.T) {
+	test_light.RunTestsWithDb(
+		provisionDb,
+		[]test_light.Test{
+			test_light.Test{
+				TestName: "Test Getting normal jobmine jobs",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
+					rlog.Infof("test 1")
+					job1, err := createTestJob(db, runId1, testJobType)
+					assert.NoError(t, err)
+
+					job2, err := createTestJob(db, runId2, testJobType2)
+					assert.NoError(t, err)
+
+					jobs, err := GetJobmineJobsToRun(db, time.Now(), nil, nil)
+					assert.NoError(t, err)
+					assert.Len(t, jobs, 2)
+					assert.Equal(t, jobs[0].ID, job1.ID)
+					assert.Equal(t, jobs[1].ID, job2.ID)
+				},
+			},
+			test_light.Test{
+				TestName: "Test Getting jobmine jobs with runId filter",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
+
+					job1, err := createTestJob(db, runId1, testJobType)
+					assert.NoError(t, err)
+
+					_, err = createTestJob(db, runId2, testJobType2)
+					assert.NoError(t, err)
+
+					jobs, err := GetJobmineJobsToRun(db, time.Now(), nil, []string{runId1})
+					assert.NoError(t, err)
+					assert.Len(t, jobs, 1)
+					assert.Equal(t, jobs[0].ID, job1.ID)
+				},
+			},
+			test_light.Test{
+				TestName: "Test Getting jobmine jobs with jobType filter",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
+					job1, err := createTestJob(db, runId1, testJobType)
+					assert.NoError(t, err)
+
+					_, err = createTestJob(db, runId2, testJobType2)
+					assert.NoError(t, err)
+
+					jobs, err := GetJobmineJobsToRun(db, time.Now(), []JobType{testJobType}, nil)
+					assert.NoError(t, err)
+					assert.Len(t, jobs, 1)
+					assert.Equal(t, jobs[0].ID, job1.ID)
+				},
+			},
+			test_light.Test{
+				TestName: "Test Getting jobmine jobs with jobType filter and runId Filter",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
+					_, err := createTestJob(db, runId1, testJobType)
+					assert.NoError(t, err)
+
+					job2, err := createTestJob(db, runId2, testJobType2)
+					assert.NoError(t, err)
+
+					_, err = createTestJob(db, runId3, testJobType2)
+					assert.NoError(t, err)
+
+					jobs, err := GetJobmineJobsToRun(db, time.Now(), []JobType{testJobType2}, []string{runId2})
+					assert.NoError(t, err)
+					assert.Len(t, jobs, 1)
+					assert.Equal(t, jobs[0].ID, job2.ID)
+				},
+			},
+		})
+}
+
+const (
+	jobId1 uint = 1
+	jobId2 uint = 2
+	jobId3 uint = 3
+)
+
+func TestGetJobmineTasksToRun(t *testing.T) {
+	test_light.RunTestsWithDb(
+		provisionDb,
+		[]test_light.Test{
+			test_light.Test{
+				TestName: "Test Getting jobmine tasks",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
+					testTask, err := createTestTask(db, jobId1, runId1, testJobType)
+					assert.NoError(t, err)
+
+					testTask2, err := createTestTask(db, jobId2, runId2, testJobType2)
+					assert.NoError(t, err)
+
+					jobs, err := GetJobmineTasksToRun(db, nil, nil)
+					assert.NoError(t, err)
+					assert.Len(t, jobs, 2)
+					assert.Equal(t, jobs[0].ID, testTask.ID)
+					assert.Equal(t, jobs[1].ID, testTask2.ID)
+				},
+			},
+			test_light.Test{
+				TestName: "Test Getting jobmine tasks by runId filter",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
+					testTask, err := createTestTask(db, jobId1, runId1, testJobType)
+					assert.NoError(t, err)
+
+					_, err = createTestTask(db, jobId2, runId2, testJobType2)
+					assert.NoError(t, err)
+
+					jobs, err := GetJobmineTasksToRun(db, nil, []string{runId1})
+					assert.NoError(t, err)
+					assert.Len(t, jobs, 1)
+					assert.Equal(t, jobs[0].ID, testTask.ID)
+				},
+			},
+			test_light.Test{
+				TestName: "Test Getting jobmine tasks by jobType filter",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
+					testTask, err := createTestTask(db, jobId1, runId1, testJobType)
+					assert.NoError(t, err)
+
+					_, err = createTestTask(db, jobId2, runId2, testJobType2)
+					assert.NoError(t, err)
+
+					jobs, err := GetJobmineTasksToRun(db, []JobType{testJobType}, nil)
+					assert.NoError(t, err)
+					assert.Len(t, jobs, 1)
+					assert.Equal(t, jobs[0].ID, testTask.ID)
+				},
+			},
+			test_light.Test{
+				TestName: "Test Getting jobmine tasks by runId and job type filter",
+				Test: func(db *gorm.DB) {
+					resetDB(db)
+					_, err := createTestTask(db, jobId1, runId1, testJobType)
+					assert.NoError(t, err)
+
+					testTask2, err := createTestTask(db, jobId2, runId2, testJobType2)
+					assert.NoError(t, err)
+
+					_, err = createTestTask(db, jobId3, runId3, testJobType2)
+					assert.NoError(t, err)
+
+					jobs, err := GetJobmineTasksToRun(db, []JobType{testJobType2}, []string{runId2})
+					assert.NoError(t, err)
+					assert.Len(t, jobs, 1)
+					assert.Equal(t, jobs[0].ID, testTask2.ID)
+				},
+			},
+		})
 }

--- a/server/jobmine/job_record.go
+++ b/server/jobmine/job_record.go
@@ -40,3 +40,24 @@ func (jr *JobRecord) SetJobStatus(db *gorm.DB, status Status) error {
 	jr.Status = status
 	return db.Save(jr).Error
 }
+
+func CreateJobRecord(db *gorm.DB, runId string, jobType JobType, metadata Metadata, startTime *time.Time) (*JobRecord, error) {
+
+	// by default start now
+	if startTime == nil {
+		var now = time.Now()
+		startTime = &now
+	}
+
+	jobRecord := JobRecord{
+		RunId:     runId,
+		JobType:   jobType,
+		Metadata:  metadata,
+		Status:    STATUS_CREATED,
+		StartTime: *startTime,
+	}
+	if err := db.Save(&jobRecord).Error; err != nil {
+		return nil, err
+	}
+	return &jobRecord, nil
+}

--- a/server/jobmine/task_record.go
+++ b/server/jobmine/task_record.go
@@ -64,3 +64,18 @@ func (r *TaskRecord) GetJobRecordForTask(db *gorm.DB) (JobRecord, error) {
 	err := db.First(&jobRecord, r.JobId).Error
 	return jobRecord, err
 }
+
+// CreateTaskRecord Creates a new task record in the db
+func CreateTaskRecord(db *gorm.DB, jobId uint, runId string, jobType JobType, metadata Metadata) (*TaskRecord, error) {
+	taskRecord := TaskRecord{
+		JobId:    jobId,
+		RunId:    runId,
+		JobType:  jobType,
+		Metadata: metadata,
+		Status:   STATUS_CREATED,
+	}
+	if err := db.Save(&taskRecord).Error; err != nil {
+		return nil, err
+	}
+	return &taskRecord, nil
+}

--- a/server/jobmine_jobs/remind_meetup_job/remind_meetup_job.go
+++ b/server/jobmine_jobs/remind_meetup_job/remind_meetup_job.go
@@ -200,10 +200,10 @@ func CreateReminderJob(db *gorm.DB, runId string) error {
 	metadata := map[string]interface{}{}
 
 	if _, err := jobmine.CreateJobRecord(
-		JobType:  REMIND_MEETUP_JOB,
-		RunId:    runId,
-		Metadata: metadata,
-		Status:   jobmine.STATUS_CREATED,
+		runId,
+		REMIND_MEETUP_JOB,
+		metadata,
+		nil,
 	); err != nil {
 		return err
 	}

--- a/server/jobmine_jobs/remind_meetup_job/remind_meetup_job.go
+++ b/server/jobmine_jobs/remind_meetup_job/remind_meetup_job.go
@@ -200,6 +200,7 @@ func CreateReminderJob(db *gorm.DB, runId string) error {
 	metadata := map[string]interface{}{}
 
 	if _, err := jobmine.CreateJobRecord(
+		db,
 		runId,
 		REMIND_MEETUP_JOB,
 		metadata,

--- a/server/jobmine_jobs/remind_meetup_job/remind_meetup_job.go
+++ b/server/jobmine_jobs/remind_meetup_job/remind_meetup_job.go
@@ -199,12 +199,12 @@ var ReminderJobSpec jobmine.JobSpec = jobmine.JobSpec{
 func CreateReminderJob(db *gorm.DB, runId string) error {
 	metadata := map[string]interface{}{}
 
-	if err := db.Create(&jobmine.JobRecord{
+	if _, err := jobmine.CreateJobRecord(
 		JobType:  REMIND_MEETUP_JOB,
 		RunId:    runId,
 		Metadata: metadata,
 		Status:   jobmine.STATUS_CREATED,
-	}).Error; err != nil {
+	); err != nil {
 		return err
 	}
 	return nil

--- a/server/jobmine_jobs/remind_onboard_job/remind_onboard_job.go
+++ b/server/jobmine_jobs/remind_onboard_job/remind_onboard_job.go
@@ -331,12 +331,8 @@ func usersWithoutGroup(db *gorm.DB) ([]data.TUserID, error) {
 
 // CreateReminderJob Creates a reminder job record to get run at some point.
 func CreateReminderJob(db *gorm.DB, runId string) error {
-	if err := db.Create(&jobmine.JobRecord{
-		JobType:  REMIND_ONBOARD_JOB,
-		RunId:    runId,
-		Metadata: map[string]interface{}{},
-		Status:   jobmine.STATUS_CREATED,
-	}).Error; err != nil {
+	_, err := jobmine.CreateJobRecord(db, runId, REMIND_ONBOARD_JOB, map[string]interface{}{}, nil)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/server/jobmine_jobs/test_job/test_job_spec.go
+++ b/server/jobmine_jobs/test_job/test_job_spec.go
@@ -34,12 +34,8 @@ var TestJobSpec jobmine.JobSpec = jobmine.JobSpec{
 
 // CreateTestJob Creates a test job record
 func CreateTestJob(db *gorm.DB, runId string, metadata jobmine.Metadata) error {
-	if err := db.Create(&jobmine.JobRecord{
-		JobType:  TestJob,
-		RunId:    runId,
-		Metadata: metadata,
-		Status:   jobmine.STATUS_CREATED,
-	}).Error; err != nil {
+	_, err := jobmine.CreateJobRecord(db, runId, TestJob, metadata, nil)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/server/jobmine_jobs/welcome_back_email_job/welcome_back_email_job.go
+++ b/server/jobmine_jobs/welcome_back_email_job/welcome_back_email_job.go
@@ -200,12 +200,8 @@ func CreateEmailJob(
 		metadata[TEST_USER_ID_METADATA_KEY] = strconv.Itoa(int(*testUserId))
 	}
 
-	if err := db.Create(&jobmine.JobRecord{
-		JobType:  WELCOME_BACK_EMAIL_JOB,
-		RunId:    runId,
-		Metadata: metadata,
-		Status:   jobmine.STATUS_CREATED,
-	}).Error; err != nil {
+	_, err := jobmine.CreateJobRecord(db, runId, WELCOME_BACK_EMAIL_JOB, metadata, nil)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/server/jobmine_utility/test_helpers.go
+++ b/server/jobmine_utility/test_helpers.go
@@ -24,11 +24,11 @@ func RunAndTestRunners(t *testing.T, db *gorm.DB, runId string, specStore jobmin
 	assert.NoError(t, err)
 
 	// schedule tasks
-	err = jobmine.JobRunner(specStore, db)
+	err = jobmine.JobRunner(specStore, db, nil, nil)
 	assert.NoError(t, err)
 
 	// run tasks
-	err = jobmine.TaskRunner(specStore, db)
+	err = jobmine.TaskRunner(specStore, db, nil, nil)
 	assert.NoError(t, err)
 
 	// update the state of all tasks

--- a/server/jobs/job_runner/main.go
+++ b/server/jobs/job_runner/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"flag"
 	"letstalk/server/jobmine"
 	"letstalk/server/jobmine_jobs"
 	"letstalk/server/utility"
 
 	"github.com/romana/rlog"
+)
+
+// NOTE: flags are conjunctive as in the conditions are ANDed together
+var (
+	jobTypeFilter = flag.String("jobTypeFilter", "", "Job Types to run")
+	runIdFilter   = flag.String("runIdFilter", "", "Run Id to run")
 )
 
 func main() {
@@ -15,8 +22,23 @@ func main() {
 		panic(err)
 	}
 
+	var jobTypes []jobmine.JobType
+	var runIds []string
+
+	if jobTypeFilter != "" {
+		rawTypes = utility.ParseListCommandLineFlags(jobTypeFilter)
+		jobTypes = make([]jobmine.JobType, 0)
+		for _, t := range rawTypes {
+			jobTypes = append(jobTypes, jobmine.JobType(t))
+		}
+	}
+
+	if runIdFilter != "" {
+		runIds = utility.ParseListCommandLineFlags(runIdFilter)
+	}
+
 	// create new job runner to run jobs
-	err = jobmine.JobRunner(jobmine_jobs.Jobs, db)
+	err = jobmine.JobRunner(jobmine_jobs.Jobs, db, jobTypes, runIds)
 	if err != nil {
 		rlog.Errorf("Job runner ran into exception: %+v", err)
 		panic(err)

--- a/server/jobs/job_runner/main.go
+++ b/server/jobs/job_runner/main.go
@@ -25,16 +25,16 @@ func main() {
 	var jobTypes []jobmine.JobType
 	var runIds []string
 
-	if jobTypeFilter != "" {
-		rawTypes = utility.ParseListCommandLineFlags(jobTypeFilter)
+	if jobTypeFilter != nil && *jobTypeFilter != "" {
+		rawTypes := utility.ParseListCommandLineFlags(*jobTypeFilter)
 		jobTypes = make([]jobmine.JobType, 0)
 		for _, t := range rawTypes {
 			jobTypes = append(jobTypes, jobmine.JobType(t))
 		}
 	}
 
-	if runIdFilter != "" {
-		runIds = utility.ParseListCommandLineFlags(runIdFilter)
+	if runIdFilter != nil && *runIdFilter != "" {
+		runIds = utility.ParseListCommandLineFlags(*runIdFilter)
 	}
 
 	// create new job runner to run jobs

--- a/server/jobs/manual_job_scheduler/main.go
+++ b/server/jobs/manual_job_scheduler/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	// actually create the job.
-	if _, err := jobmine.CreateJobRecord(db, *runId, jobType, metadata, nil); err != nil {
+	if _, err := jobmine.CreateJobRecord(db, *runId, jobType, parsedMetadata, nil); err != nil {
 		rlog.Errorf("Failed to schedule reminder job.")
 		panic(err)
 	}

--- a/server/jobs/manual_job_scheduler/main.go
+++ b/server/jobs/manual_job_scheduler/main.go
@@ -42,12 +42,7 @@ func main() {
 	}
 
 	// actually create the job.
-	if err := db.Create(&jobmine.JobRecord{
-		JobType:  jobType,
-		RunId:    *runId,
-		Metadata: parsedMetadata,
-		Status:   jobmine.STATUS_CREATED,
-	}).Error; err != nil {
+	if _, err := jobmine.CreateJobRecord(db, *runId, jobType, metadata, nil); err != nil {
 		rlog.Errorf("Failed to schedule reminder job.")
 		panic(err)
 	}

--- a/server/jobs/manual_task_scheduler/main.go
+++ b/server/jobs/manual_task_scheduler/main.go
@@ -51,7 +51,7 @@ func main() {
 	}
 	tx := db.Begin()
 
-	jobRecord, err = jobmine.CreateJobRecord(tx, *runId, jobType, parsedJobMetadata, nil)
+	jobRecord, err := jobmine.CreateJobRecord(tx, *runId, jobType, parsedJobMetadata, nil)
 	// actually create the job.
 	if err != nil {
 		tx.Rollback()
@@ -60,7 +60,7 @@ func main() {
 	}
 	rlog.Infof("Successfully created job.")
 
-	taskRecord, err = jobmine.CreateTaskRecord(tx, jobRecord.ID, *runId, jobType, parsedTaskMetadata)
+	taskRecord, err := jobmine.CreateTaskRecord(tx, jobRecord.ID, *runId, jobType, parsedTaskMetadata)
 	if err := db.Create(&taskRecord).Error; err != nil {
 		tx.Rollback()
 		rlog.Errorf("Failed to create task")

--- a/server/jobs/manual_task_scheduler/main.go
+++ b/server/jobs/manual_task_scheduler/main.go
@@ -51,27 +51,16 @@ func main() {
 	}
 	tx := db.Begin()
 
-	var jobRecord = jobmine.JobRecord{
-		JobType:  jobType,
-		RunId:    *runId,
-		Metadata: parsedJobMetadata,
-		Status:   jobmine.STATUS_SUCCESS,
-	}
+	jobRecord, err = jobmine.CreateJobRecord(tx, *runId, jobType, parsedJobMetadata, nil)
 	// actually create the job.
-	if err := tx.Create(&jobRecord).Error; err != nil {
+	if err != nil {
 		tx.Rollback()
 		rlog.Errorf("Failed to create job")
 		panic(err)
 	}
 	rlog.Infof("Successfully created job.")
 
-	var taskRecord = &jobmine.TaskRecord{
-		JobId:    jobRecord.ID,
-		RunId:    *runId,
-		JobType:  jobType,
-		Metadata: parsedTaskMetadata,
-		Status:   jobmine.STATUS_CREATED,
-	}
+	taskRecord, err = jobmine.CreateTaskRecord(tx, jobRecord.ID, *runId, jobType, parsedTaskMetadata)
 	if err := db.Create(&taskRecord).Error; err != nil {
 		tx.Rollback()
 		rlog.Errorf("Failed to create task")

--- a/server/jobs/task_runner/main.go
+++ b/server/jobs/task_runner/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"letstalk/server/constants"
 	"letstalk/server/jobmine"
 	"letstalk/server/jobmine_jobs"
@@ -11,12 +12,33 @@ import (
 	"github.com/romana/rlog"
 )
 
+// NOTE: flags are conjunctive as in the conditions are ANDed together
+var (
+	jobTypeFilter = flag.String("jobTypeFilter", "", "Job Types to run")
+	runIdFilter   = flag.String("runIdFilter", "", "Run Id to run")
+)
+
 func main() {
 	utility.Bootstrap()
 	db, err := utility.GetDB()
 	if err != nil {
 		rlog.Errorf("Unable to get database: %+v", err)
 		panic(err)
+	}
+
+	var jobTypes []jobmine.JobType
+	var runIds []string
+
+	if jobTypeFilter != "" {
+		rawTypes = utility.ParseListCommandLineFlags(jobTypeFilter)
+		jobTypes = make([]jobmine.JobType, 0)
+		for _, t := range rawTypes {
+			jobTypes = append(jobTypes, jobmine.JobType(t))
+		}
+	}
+
+	if runIdFilter != "" {
+		runIds = utility.ParseListCommandLineFlags(runIdFilter)
 	}
 
 	rlog.Debugf("Queue processing")
@@ -33,7 +55,7 @@ func main() {
 
 		// create new task runner
 		rlog.Debug("Running tasks")
-		err = jobmine.TaskRunner(jobmine_jobs.Jobs, db)
+		err = jobmine.TaskRunner(jobmine_jobs.Jobs, db, jobTypes, runIds)
 		if err != nil {
 			rlog.Errorf("Task runner ran into exception: %+v", err)
 			panic(err)

--- a/server/jobs/task_runner/main.go
+++ b/server/jobs/task_runner/main.go
@@ -29,16 +29,16 @@ func main() {
 	var jobTypes []jobmine.JobType
 	var runIds []string
 
-	if jobTypeFilter != "" {
-		rawTypes = utility.ParseListCommandLineFlags(jobTypeFilter)
+	if jobTypeFilter != nil && *jobTypeFilter != "" {
+		rawTypes := utility.ParseListCommandLineFlags(*jobTypeFilter)
 		jobTypes = make([]jobmine.JobType, 0)
 		for _, t := range rawTypes {
 			jobTypes = append(jobTypes, jobmine.JobType(t))
 		}
 	}
 
-	if runIdFilter != "" {
-		runIds = utility.ParseListCommandLineFlags(runIdFilter)
+	if runIdFilter != nil && *runIdFilter != "" {
+		runIds = utility.ParseListCommandLineFlags(*runIdFilter)
 	}
 
 	rlog.Debugf("Queue processing")

--- a/server/utility/common.go
+++ b/server/utility/common.go
@@ -2,6 +2,7 @@ package utility
 
 import (
 	"letstalk/server/core/secrets"
+	"strings"
 
 	"github.com/namsral/flag"
 )
@@ -56,4 +57,11 @@ func IsProductionEnvironment() bool {
 func GetDeeplinkPrefix() string {
 	checkBootstrapped()
 	return secrets.GetSecrets().DeeplinkPrefix
+}
+
+const listDelimeter = ","
+
+// ParseListCommandLineFlags Breaks up a list in command line flags
+func ParseListCommandLineFlags(argument string) []string {
+	return strings.Split(argument, listDelimeter)
 }


### PR DESCRIPTION
This change makes it so that the jobmine job and task runners can have better granularity for scheduling. For example, suppose we only want to run a specific job with jobId or a specific job type (and not all available jobs).

The changes are trivial and the bulk of this PR are testing to make sure filtering works properly and actually converting places in the code to use the new interface.