### PR TITLE
Add code to inject cookie to webview.

### DIFF
--- a/letstalk/src/views/NotificationContentView.tsx
+++ b/letstalk/src/views/NotificationContentView.tsx
@@ -61,10 +61,16 @@ class NotificationContentView extends React.Component<Props, State> {
       return `${BASE_URL}${NOTIFICATION_PAGE_ROUTE}?notificationId=${notificationId}`;
     }
 
+    private getJavaScriptCookieInjector(sessionId: string): string {
+      return `(function(){document.cookie="sessionId=${sessionId};";})();`;
+    }
+
     render() {
       const url = this.getNotificationPage(this.notificationId);
       if (this.state.sessionId !== undefined && this.state.sessionId !== null) {
-        return <WebView source={{
+        return <WebView 
+        injectedJavaScript={this.getJavaScriptCookieInjector(this.state.sessionId)}
+        source={{
           uri: url,
           headers: {"sessionId": this.state.sessionId}
         }} />;


### PR DESCRIPTION
The WebView for a notification needs access to the sessionId in order to make authenticated api requests. This change injects the cookie so that it is accessible to the WebView. There is no way to set cookies in a WebView manually so instead we just run a javascript snipped on the WebView to set a cookie. 

I tested by making sure that the javascript was being run on the webview and that the sessionId was propagated to the javascript. I injected an artificial alert to see the cookie.

![screenshot_20190221-233517](https://user-images.githubusercontent.com/2242730/53220431-7cb4d000-3632-11e9-81b4-0873661a1318.jpg)
