### PR TITLE
Updated to new sendgrid api (transactional)

### DIFF
--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -284,15 +284,14 @@
   version = "v2.4.1"
 
 [[projects]]
-  digest = "1:bf326e9bc2c70dfc765590bfa9c9985e41355f7972fb50e7f052440f3a5122a2"
+  digest = "1:2a4649b34b820ea54ed9983d61880ef675115fa111d40493fe3491eb5f109732"
   name = "github.com/sendgrid/sendgrid-go"
   packages = [
     ".",
     "helpers/mail",
   ]
   pruneopts = "UT"
-  revision = "8caf17aa96b4a98bae8bd216878dd50ff12897b5"
-  version = "v3.4.1"
+  revision = "49fb945410d3b36be6eecdfa5ce91210e8b2b807"
 
 [[projects]]
   digest = "1:1bc4a5bd879ce6b44fdaa2e8e1144921c145604764e92220009b951c1f2439f5"

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -67,7 +67,7 @@
 
 [[constraint]]
   name = "github.com/sendgrid/sendgrid-go"
-  version = "3.4.1"
+  revision = "49fb945410d3b36be6eecdfa5ce91210e8b2b807"
 
 [[constraint]]
   name = "github.com/jinzhu/gorm"


### PR DESCRIPTION
I added a helper method to take advantage of the new sendgrid api. The motivation for this is because the new system supports arbitrary dictionary as templating parameters (which works really nicely with the generic notification job framework).

I'm landing this because its a dependency for my notification job.
What a template looks like:
![screen shot 2019-03-03 at 12 45 47 am](https://user-images.githubusercontent.com/2242730/53691520-b8941780-3d4d-11e9-99fb-3e23987a5584.png)

Templated email
![screen shot 2019-03-03 at 12 41 47 am](https://user-images.githubusercontent.com/2242730/53691517-a0bc9380-3d4d-11e9-9ea6-a7df1fbdc6ed.png)
