### PR TITLE
Made timestamp optional on data model.

### DIFF
--- a/server/core/api/notification.go
+++ b/server/core/api/notification.go
@@ -13,7 +13,7 @@ type Notification struct {
 	State          data.NotifState        `json:"state"`
 	Title          string                 `json:"title"`
 	Message        string                 `json:"message"`
-	Timestamp      time.Time              `json:"timestamp"`
+	Timestamp      *time.Time             `json:"timestamp"`
 	ThumbnailLink  *string                `json:"thumbnail"`
 	Data           map[string]interface{} `json:"data"`
 	Link           *string                `json:"link"`

--- a/server/core/notifications/notification_helpers.go
+++ b/server/core/notifications/notification_helpers.go
@@ -79,7 +79,7 @@ func CreateNotification(
 		Title:         title,
 		Message:       message,
 		ThumbnailLink: thumbnail,
-		Timestamp:     createdAt,
+		Timestamp:     &createdAt,
 		Link:          &link,
 		RunId:         runId,
 	}

--- a/server/data/notification.go
+++ b/server/data/notification.go
@@ -36,7 +36,7 @@ type Notification struct {
 	UserId        TUserID               `gorm:"not null"`
 	User          User                  `gorm:"foreignkey:UserId"`
 	Type          NotifType             `gorm:"not null;size:190"`
-	Timestamp     time.Time             `gorm:"not null"` // when the notification was created in the system (not in db)
+	Timestamp     *time.Time            `gorm:"null"` // when the notification was created in the system (not in db)
 	State         NotifState            `gorm:"not null;size:190"`
 	Title         string                `gorm:"not null;size:190"`
 	Message       string                `gorm:"not null;type:text"`

--- a/server/data/spinup.go
+++ b/server/data/spinup.go
@@ -580,6 +580,16 @@ func migrateDB(db *gorm.DB) {
 				return nil
 			},
 		},
+		{
+			ID: "Update notification data model to have optional timestamp",
+			Migrate: func(tx *gorm.DB) error {
+				// Builds a unique index on (user,group)
+				return tx.AutoMigrate(Notification{}).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {


### PR DESCRIPTION
Timestamp semantics changed a bit when we migrated off of sqs and it is essentially the `createdAt` time. Before we we're setting the time to a ZERO time but now it makes sense to just leave it nullable until we set a value.