### PR TITLE
Add api module framework to user webapp. Also migrate me endpoint

### DIFF
--- a/server/web/src/api/api_controller.js
+++ b/server/web/src/api/api_controller.js
@@ -1,4 +1,5 @@
 import { loginUrl, logoutUrl, meUrl, signupUrl, mentorshipUrl, deleteUrl, getGroupMembersUrlBase, getManagedGroupsUrl, createNewManagedGroupUrl, registerWithManagedGroupUrl, getMatchRoundsUrl, createMatchRoundsUrl, userGroupUrl, matchRoundUrl } from '../config.js'
+import {meApiModule} from './me_api_module';
 import axios from 'axios';
 import Cookies from 'universal-cookie';
 
@@ -17,38 +18,15 @@ export function didAuthenticateAction(sessionId) {
     return {type: DID_AUTHENTICATE_ACTION, sessionId: sessionId}
 }
 
-export function shouldFetchProfileAction() {
-    return {type: FETCH_PROFILE};
-}
-
-export function fetchingProfileAction() {
-    return {type: FETCHING_PROFILE};
-}
-
-export function didFetchProfileAction(profile) {
-    return {type: DID_FETCH_PROFILE, profile: profile};
-}
-
-export function fetchProfileErrorAction(error) {
-    return {type: FETCH_PROFILE_ERROR, error: error};
-}
-
 // Invalidate authentication
 export function authExpiredAction() {
     return {type: AUTH_EXPIRED};
-}
-
-export function getShouldFetchProfile(state) {
-    return state.apiServiceReducer.shouldFetchProfile;
 }
 
 export function isAuthenticated(state) {
     return state.apiServiceReducer.isValid;
 }
 
-export function getProfile(state) {
-    return state.apiServiceReducer.profile;
-}
 
 // base state
 const initialState = {
@@ -59,14 +37,6 @@ const initialState = {
 
 export function apiServiceReducer(state = initialState, action) {
     switch(action.type) {
-        case FETCH_PROFILE:
-            return Object.assign({}, state, {shouldFetchProfile: true});
-        case FETCHING_PROFILE:
-            return Object.assign({}, state, {shouldFetchProfile: false});
-        case DID_FETCH_PROFILE:
-            return Object.assign({}, state, {shouldFetchProfile: false, profile: action.profile});
-        case FETCH_PROFILE_ERROR:
-            return Object.assign({}, state, {shouldFetchProfile: false, fetchProfileError: action.error});
         case DID_AUTHENTICATE_ACTION:
             return Object.assign({}, state, {isValid: true, sessionId: action.sessionId})
         case AUTH_EXPIRED:
@@ -94,7 +64,7 @@ export const HiveApiService = ((state, dispatch) => {
 
         setSessionId: (sessionId) => {
             (new Cookies()).set('sessionId', sessionId);
-            dispatch(shouldFetchProfileAction());
+            dispatch(meApiModule.getApiExecuteAction());
             dispatch(didAuthenticateAction(sessionId));
         },
 
@@ -147,7 +117,7 @@ export const HiveApiService = ((state, dispatch) => {
             return apiService().hiveFetch(logoutUrl, 'POST', undefined);
         },
 
-        me: (started, done, error) => {
+        me: ({started, done, error}) => {
             started();
             return apiService().hiveFetch(meUrl, 'GET', undefined)
                 .then((data) => done(data))

--- a/server/web/src/api/me_api_module.js
+++ b/server/web/src/api/me_api_module.js
@@ -1,0 +1,17 @@
+import {apiModule, pluggableApiModule} from './api_module';
+
+// This needs to be unique from other apis
+export const API_NAME = "meApi";
+// this needs to match the name of the function in HiveApiService
+export const API_FUNC = "me";
+
+const initialDataState = {
+    /* This api has no data */
+}
+
+export const meApiModule = apiModule(API_NAME);
+export const meApi = pluggableApiModule(
+    meApiModule,
+    API_FUNC, 
+    initialDataState,
+);

--- a/server/web/src/index.jsx
+++ b/server/web/src/index.jsx
@@ -18,9 +18,10 @@ import DeleteUserToolPage from './user_delete_tool.jsx';
 import ManagedGroupPage from './managed_group.jsx';
 import {API_NAME as MATCH_ROUND_API, matchRoundApi, DELETE_API_NAME as DELETE_MATCH_ROUND_API_NAME, deleteMatchRoundApi} from './api/match_round_api_module';
 import {API_NAME as DELETE_USER_GROUP_API, userGroupDeleteApi} from './api/user_group_delete_api_module';
+import {API_NAME as ME_API, meApi} from './api/me_api_module';
 import {getManagedGroupsReducer, getShouldFetchGroups, fetchingGroupsAction, gotGroupsAction, errorFetchingGroupsAction} from './get_managed_groups_view'
 import {membersReducer, getShouldFetchMembers, fetchingMembersAction, gotMembersAction, errorFetchingMembersAction, getGroupToFetch} from './members';
-import {apiServiceReducer, HiveApiService, getShouldFetchProfile, didFetchProfileAction, fetchingProfileAction, fetchProfileErrorAction} from './api/api_controller';
+import {apiServiceReducer, HiveApiService} from './api/api_controller';
 
 import AuthenticatedRoute from './authenticate_component.jsx';
 import { loginPath, signupPath, adhocAddToolPath, landingPath, deleteUserToolPath, groupManagementToolPath, matchingPath, membersPath } from './routes.js';
@@ -30,6 +31,7 @@ const apiModules = {
     [MATCH_ROUND_API]: matchRoundApi,
     [DELETE_USER_GROUP_API]: userGroupDeleteApi,
     [DELETE_MATCH_ROUND_API_NAME]: deleteMatchRoundApi,
+    [ME_API]: meApi,
 }
 
 // build reducer dict
@@ -67,16 +69,6 @@ function onLoad() {
                 () => {store.dispatch(fetchingGroupsAction())},
                 (data) => {store.dispatch(gotGroupsAction(data.Result.managedGroups))},
                 (err) => {store.dispatch(errorFetchingGroupsAction(err))}
-            );
-        }
-
-        let shouldFetchProfile = getShouldFetchProfile(store.getState());
-        if (!!shouldFetchProfile) {
-            console.log("Fetching profile");
-            HiveApiService(store.getState(), store.dispatch).me(
-                () => {store.dispatch(fetchingProfileAction())},
-                (data) => {store.dispatch(didFetchProfileAction(data.Result))},
-                (err) => {store.dispatch(fetchProfileErrorAction(err))}
             );
         }
 

--- a/server/web/src/navbar_container.jsx
+++ b/server/web/src/navbar_container.jsx
@@ -9,6 +9,7 @@ import {adhocAddToolPath, deleteUserToolPath, loginPath, logoutPath, membersPath
 import {logoutAction} from './login';
 import {shouldFetchProfileAction, isAuthenticated, getProfile} from './api/api_controller'
 import apiServiceConnect from './api/api_service_connect';
+import {meApiModule} from './api/me_api_module';
 
 class NavbarContainer extends React.Component {
 
@@ -119,14 +120,14 @@ class NavbarContainer extends React.Component {
 const NavbarContainerComponent = apiServiceConnect(
     (state) => {
         return {
-            profile: getProfile(state),
+            profile: meApiModule.getData(state),
             isAuthenticated: isAuthenticated(state)
         };
     },
     (dispatch) => {
         return {
             didLogout: (state) => {dispatch(logoutAction(state))},
-            fetchProfile: () => {dispatch(shouldFetchProfileAction())}
+            fetchProfile: () => {dispatch(meApiModule.getApiExecuteAction())}
         };
     }
 )(CookieAwareComponent(withCookies(NavbarContainer)));


### PR DESCRIPTION
Adds the api module framework to the user webapp. The `me` endpoint is also migrated away from using the original api machinery to use the new api module framework as an example.